### PR TITLE
Fixed non-working example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ img_path = "image.png"
 mask_path = "mask.png"
 
 image = Image.open(img_path)
-mask = Image.open(mask_path)
+mask = Image.open(mask_path).convert('L')
 
 result = simple_lama(image, mask)
 result.save("inpainted.png")


### PR DESCRIPTION
Before that change "RuntimeError: Given groups=1, weight of size [64, 4, 7, 7], expected input[1, 6, 1006, 1510] to have 4 channels, but got 6 channels instead" had been throwing