### PR TITLE
fix dim err for mask in ndarray to 1 channel from 3

### DIFF
--- a/simple_lama_inpainting/utils/util.py
+++ b/simple_lama_inpainting/utils/util.py
@@ -9,13 +9,16 @@ from urllib.parse import urlparse
 
 
 # Source https://github.com/advimman/lama
-def get_image(image):
+def get_image(image,mask=True):
     if isinstance(image, Image.Image):
         img = np.array(image)
     elif isinstance(image, np.ndarray):
         img = image.copy()
     else:
         raise Exception("Input image should be either PIL Image or numpy array!")
+
+    if mask and img.ndim != 1:
+      img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
     if img.ndim == 3:
         img = np.transpose(img, (2, 0, 1))  # chw
@@ -62,7 +65,7 @@ def pad_img_to_modulo(img, mod):
 
 def prepare_img_and_mask(image, mask, device, pad_out_to_modulo=8, scale_factor=None):
     out_image = get_image(image)
-    out_mask = get_image(mask)
+    out_mask = get_image(mask,mask=True)
 
     if scale_factor is not None:
         out_image = scale_image(out_image, scale_factor)

--- a/simple_lama_inpainting/utils/util.py
+++ b/simple_lama_inpainting/utils/util.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 
 # Source https://github.com/advimman/lama
-def get_image(image,mask=True):
+def get_image(image,mask=False):
     if isinstance(image, Image.Image):
         img = np.array(image)
     elif isinstance(image, np.ndarray):


### PR DESCRIPTION
I have encountered a runtime error while processing an input image in ndarray with the format (image, mask). The error specifically states: 'RuntimeError: Given groups=1, the weight of size [64, 4, 7, 7], expected input[1, 2, 1806, 2406] to have 4 channels, but got 2 channels instead.' To address this issue, I made modifications to the 'get_image' function. Now, it checks the number of dimensions in the mask image before transposing the channels to the first index. This adjustment is crucial when the user's mask image has three channels.